### PR TITLE
Remove the Data::Dumper::Names library, as it isn't used

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@ a bot citizen on an IRC channel as possible, from completely ignoring
 the channel it's in (supposing you're running it in your own instance)
 to filtering in only certian URLs.
 
-- [ ] TODO: add filtering OUT as well, see Issue [#1](https://github.com/tamouse/irssi-showtitle/issues/1)
-
 [irssi]: https://irssi.org/ "IRSSI IRC client"
 
 Documentation for the script is kept as perldoc in the script.
@@ -18,3 +16,21 @@ I haven't touched this really much in several years, but if you wish,
 I'll accept PRs with bug-fixes and enhancements.
 
 The code is still licensed GPLv2.
+
+## Live testing
+
+To live test the script, start up `irssi` as follows:
+
+    irssi --home=. --config=irssi-config
+
+Load the script: `/script load showtitle.pl`.
+
+Connect to Freenode: `/connect freenode`.
+
+Turn on script debugging: `/stdebug on`.
+
+Join the testing channel `/join ##showtitle-test`.
+
+From another user in the channel, enter a test url.
+
+Watch the debug output in the status window.

--- a/scripts/showtitle.pl
+++ b/scripts/showtitle.pl
@@ -1,7 +1,7 @@
 # showtitle3.pl -- Irssi script to show <title> of URLs
 ## Copyright (c) 2010 Tamara Temple <tamouse@gmail.com>
-## Time-stamp: <2017-12-31 17:59:23 tamara>
-## VERSION: 3.3.2
+## Time-stamp: <2017-12-31 18:32:09 tamara>
+## VERSION: 3.3.3
 #   - Copyright (C) 2012 Tamara Temple Web Development
 #   -
 #   - This program is free software; you can redistribute it and/or
@@ -207,11 +207,10 @@ turns debugging for showtitle script on or off, or reports status
 =cut
 
 use Irssi qw();
-use Data::Dumper::Names;
 use strict;
 use vars qw($VERSION %IRSSI);
 
-$VERSION = "3.3.2";
+$VERSION = "3.3.3";
 
 %IRSSI = (
   'authors'	=> 'Tamara Temple, Jess',


### PR DESCRIPTION
Move the script under the `scripts/` directory.
Update the README.